### PR TITLE
Fix header line format, so package.el can parse it correctly

### DIFF
--- a/linked-buffer.el
+++ b/linked-buffer.el
@@ -1,4 +1,4 @@
-;; linked-buffer.el --- One buffer as a view of another -*- lexical-binding: t -*-
+;;; linked-buffer.el --- One buffer as a view of another -*- lexical-binding: t -*-
 
 ;; This file is not part of Emacs
 


### PR DESCRIPTION
This is the reason why the package descr. is "No description available" in MELPA... :-)

It also stops the package dependencies from being extracted.
