### PR TITLE
Load 'f' for using f-equal?

### DIFF
--- a/lentic.el
+++ b/lentic.el
@@ -154,6 +154,7 @@
 (require 'eieio)
 (require 'm-buffer)
 (require 'm-buffer-at)
+(require 'f)
 ;; #+end_src
 
 (defvar lentic-doc "lenticular.org")


### PR DESCRIPTION
`f-equal?` is used at [here](https://github.com/phillord/lentic/blob/72542b681a4febf587c89948bbcc591402a7253d/lentic.el#L503), but `f.el` is not loaded.

This causes byte-compile warning.

```
In end of data:
lentic.el:1354:1:Warning: the function `f-equal?' is not known to be defined.
```
